### PR TITLE
Remove abstract socket default

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ LOCAL_ADDR_FORWARD=tcp:$LOCAL_PORT
   ;;
   unix)
 LOCAL_ADDR=/tmp/$ANDROID_SOCK
-LOCAL_ADDR_FORWARD=localabstract:$ANDROID_SOCK
+LOCAL_ADDR_FORWARD=localfilesystem:$LOCAL_ADDR
   ;;
 esac
 


### PR DESCRIPTION
In SDK r24.3.4 localabstract actually creates an abstract socket (instead of a filesystem socket), which
is not supported by the forwarder.

Since abstract sockets are not supported by the forwarder , we use `localfilesystem:` in `adb forward` to be able to connect to the socket.
